### PR TITLE
Remove runtime scripts list from addon.json

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -31,31 +31,5 @@
     "instance.js",
     "plugin.js",
     "type.js"
-  ],
-  "runtime-scripts": [
-    {
-      "type": "module",
-      "script-path": "c3runtime/plugin.js"
-    },
-    {
-      "type": "module", 
-      "script-path": "c3runtime/type.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/instance.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/conditions.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/actions.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/expressions.js"
-    }
   ]
 }


### PR DESCRIPTION
## Summary
- clean up `addon.json` by removing the `runtime-scripts` section

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('addon.json','utf8')); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684e4be38d84832ba9feee42ea8a9a0d