### PR TITLE
Add mocha tests for addon.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/addon.json
+++ b/addon.json
@@ -31,31 +31,5 @@
     "instance.js",
     "plugin.js",
     "type.js"
-  ],
-  "runtime-scripts": [
-    {
-      "type": "module",
-      "script-path": "c3runtime/plugin.js"
-    },
-    {
-      "type": "module", 
-      "script-path": "c3runtime/type.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/instance.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/conditions.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/actions.js"
-    },
-    {
-      "type": "module",
-      "script-path": "c3runtime/expressions.js"
-    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "edb",
+  "version": "1.0.0",
+  "description": "這是一個基於Dexie資料庫的查詢插件，專為Construct 3設計。它提供了path查詢和MD5驗證功能，類似於get.js的邏輯。",
+  "main": "instance.js",
+  "scripts": {
+    "test": "mocha",
+    "test:watch": "mocha --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "mocha": "^11.6.0"
+  }
+}

--- a/test/addon.test.js
+++ b/test/addon.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('addon.json', () => {
+  const addonPath = path.join(__dirname, '..', 'addon.json');
+  const addon = JSON.parse(fs.readFileSync(addonPath, 'utf8'));
+
+  it('uses SDK v2', () => {
+    assert.strictEqual(addon['sdk-version'], 2, 'sdk-version should be 2');
+  });
+
+  it('does not include runtime-scripts field', () => {
+    assert.ok(!Object.prototype.hasOwnProperty.call(addon, 'runtime-scripts'),
+      'runtime-scripts should be removed for SDK v2');
+  });
+
+  const requiredFiles = [
+    'plugin.js',
+    'type.js',
+    'instance.js',
+    'aces.json',
+    'icon.svg',
+  ];
+
+  requiredFiles.forEach(file => {
+    it(`has required file: ${file}`, () => {
+      const filePath = path.join(__dirname, '..', file);
+      assert.ok(fs.existsSync(filePath), `${file} should exist`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- set up mocha test framework
- ensure runtime-scripts is removed from addon.json
- add tests verifying addon.json meets SDK v2 rules
- ignore node_modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e4be47a08832b826720baabafc8c9