### PR TITLE
Add missing language files

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -1,0 +1,23 @@
+{
+  "plugins": {
+    "eponesh_dexiequery": {
+      "name": "Dexie DB Query",
+      "description": "Dexie database query system with path lookup and MD5 verification",
+      "help-url": "https://www.construct.net",
+      "properties": {
+        "database-name": {
+          "name": "Database name",
+          "desc": "Name of the DexieDB database"
+        },
+        "version": {
+          "name": "Version",
+          "desc": "Database version number"
+        },
+        "enable-log": {
+          "name": "Enable log",
+          "desc": "Output debug log messages"
+        }
+      }
+    }
+  }
+}

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1,0 +1,23 @@
+{
+  "plugins": {
+    "eponesh_dexiequery": {
+      "name": "Dexie資料庫查詢",
+      "description": "基於 Dexie 的路徑查詢與 MD5 驗證",
+      "help-url": "https://www.construct.net",
+      "properties": {
+        "database-name": {
+          "name": "資料庫名稱",
+          "desc": "DexieDB 資料庫的名稱"
+        },
+        "version": {
+          "name": "版本",
+          "desc": "資料庫版本號"
+        },
+        "enable-log": {
+          "name": "啟用日誌",
+          "desc": "輸出除錯日誌"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- include missing language files for Construct plugin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e4dc1cdf0832baa185c399484071c